### PR TITLE
Skip adding domain for usernames with "@" char

### DIFF
--- a/myteam.go
+++ b/myteam.go
@@ -137,7 +137,7 @@ func (bot *myteamBot) notify(ctx context.Context, notification Notification) err
 		if myteamUser == "" {
 			myteamUser = user
 		}
-		if domain != "" {
+		if domain != "" && !strings.Contains(myteamUser, "@") {
 			myteamUser += "@" + domain
 		}
 		users[myteamUser] = access


### PR DESCRIPTION
Эта правка должна разблокировать возможность слать уведомления в чаты, если указать айди чата в **/user/map** в формате `1234@chat.agent`